### PR TITLE
Set B3 as default propagator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 ---
+# Modified by SignalFx
 version: 2.1
 
 references:
@@ -84,6 +85,13 @@ executors:
           POSTGRES_DB: postgres
 
 commands:
+  prepare_go_mod:
+    description: Sets project to act as go module
+    steps:
+      - run:
+          name: Go mod
+          command: go mod init
+
   install_rdkafka:
     description: Install rdkafka
     parameters:
@@ -155,11 +163,6 @@ commands:
         default: 3
     steps:
       - run:
-          name: Prefetch and remove conflicting golib vendored libraries
-          command: |
-            go get -v github.com/signalfx/golib/trace/...
-            rm -rf $(go env GOPATH)/src/github.com/signalfx/golib/vendor
-      - run:
           name: Fetching dependencies
           command: |
             RETRIES=<< parameters.retries >>
@@ -168,19 +171,6 @@ commands:
                 sleep 5
             done
             exit 1
-
-  get_redis:
-    parameters:
-      version:
-        type: string
-        default: master
-    steps:
-      - go_get:
-          packages: github.com/go-redis/redis
-      - run:
-          command: |
-            cd $GOPATH/src/github.com/go-redis/redis
-            git checkout << parameters.version >>
 
   get_deps:
     description: Get project dependencies
@@ -192,10 +182,20 @@ commands:
         type: string
         default: ./...
     steps:
-      - install_rdkafka
+      - prepare_go_mod
+      - install_rdkafka:
+          version: 4ffe54b4f59ee5ae3767f9f25dc14651a3384d62
       - get_grpc
-      - get_redis:
-          version: v6.15.3  # workaround for https://github.com/go-redis/redis/commit/17480c545e170cdb82762d9b0ea5733ec0c750f6
+      - go_get:
+          # workaround for https://github.com/go-redis/redis/commit/17480c545e170cdb82762d9b0ea5733ec0c750f6
+          packages: github.com/go-redis/redis@75795aa4236dc7341eefac3bbe945e68c99ef9df
+      - go_get:
+          # workaround for https://github.com/mongodb/mongo-go-driver/commit/2e90dce643ffac9852213072213ab457b6bbb62f
+          packages: go.mongodb.org/mongo-driver@0d1270edf53072da4da781b76d2e1db58831152f
+      - go_get:
+          packages: github.com/Shopify/sarama@b3a812117be917e2dd4f8cbcf4ff861e3ae7ef38
+      - go_get:
+          packages: google.golang.org/grpc@v1.2.1
       - go_get:
           options: << parameters.options >>
           packages: << parameters.packages >>

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package tracer
 
 import (
@@ -244,13 +245,13 @@ func TestSpanFinishPriority(t *testing.T) {
 
 func TestTracePriorityLocked(t *testing.T) {
 	assert := assert.New(t)
-	ddHeaders := TextMapCarrier(map[string]string{
-		DefaultTraceIDHeader:  "2",
-		DefaultParentIDHeader: "2",
-		DefaultPriorityHeader: "2",
+	b3Headers := TextMapCarrier(map[string]string{
+		b3TraceIDHeader:  "2",
+		b3SpanIDHeader: "2",
+		b3SampledHeader: "2",
 	})
 
-	ctx, err := NewPropagator(nil).Extract(ddHeaders)
+	ctx, err := NewPropagator(nil).Extract(b3Headers)
 	assert.Nil(err)
 	sctx, ok := ctx.(*spanContext)
 	assert.True(ok)
@@ -297,9 +298,9 @@ func TestNewSpanContext(t *testing.T) {
 		defer stop()
 		assert := assert.New(t)
 		ctx, err := NewPropagator(nil).Extract(TextMapCarrier(map[string]string{
-			DefaultTraceIDHeader:  "1",
-			DefaultParentIDHeader: "2",
-			DefaultPriorityHeader: "3",
+			b3TraceIDHeader:  "1",
+			b3SpanIDHeader: "2",
+			b3SampledHeader: "3",
 		}))
 		assert.Nil(err)
 		sctx, ok := ctx.(*spanContext)

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package tracer
 
 import (
@@ -77,6 +78,10 @@ func TestTextMapCarrierForeachKeyError(t *testing.T) {
 }
 
 func TestTextMapPropagatorErrors(t *testing.T) {
+	os.Setenv("DD_PROPAGATION_STYLE_INJECT", "datadog")
+	os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "datadog")
+	defer os.Unsetenv("DD_PROPAGATION_STYLE_INJECT")
+	defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
 	propagator := NewPropagator(nil)
 	assert := assert.New(t)
 
@@ -112,6 +117,8 @@ func TestTextMapPropagatorErrors(t *testing.T) {
 }
 
 func TestTextMapPropagatorInjectHeader(t *testing.T) {
+	os.Setenv("DD_PROPAGATION_STYLE_INJECT", "datadog")
+	defer os.Unsetenv("DD_PROPAGATION_STYLE_INJECT")
 	assert := assert.New(t)
 
 	propagator := NewPropagator(&PropagatorConfig{
@@ -141,6 +148,10 @@ func TestTextMapPropagatorInjectHeader(t *testing.T) {
 }
 
 func TestTextMapPropagatorOrigin(t *testing.T) {
+	os.Setenv("DD_PROPAGATION_STYLE_INJECT", "datadog")
+	os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "datadog")
+	defer os.Unsetenv("DD_PROPAGATION_STYLE_INJECT")
+	defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
 	src := TextMapCarrier(map[string]string{
 		originHeader:          "synthetics",
 		DefaultTraceIDHeader:  "1",
@@ -168,6 +179,10 @@ func TestTextMapPropagatorOrigin(t *testing.T) {
 }
 
 func TestTextMapPropagatorInjectExtract(t *testing.T) {
+	os.Setenv("DD_PROPAGATION_STYLE_INJECT", "datadog")
+	os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "datadog")
+	defer os.Unsetenv("DD_PROPAGATION_STYLE_INJECT")
+	defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
 	propagator := NewPropagator(&PropagatorConfig{
 		BaggagePrefix: "bg-",
 		TraceHeader:   "tid",
@@ -197,9 +212,6 @@ func TestTextMapPropagatorInjectExtract(t *testing.T) {
 
 func TestB3(t *testing.T) {
 	t.Run("inject", func(t *testing.T) {
-		os.Setenv("DD_PROPAGATION_STYLE_INJECT", "B3")
-		defer os.Unsetenv("DD_PROPAGATION_STYLE_INJECT")
-
 		tracer := newTracer()
 		root := tracer.StartSpan("web.request").(*span)
 		root.SetTag(ext.SamplingPriority, -1)
@@ -217,9 +229,6 @@ func TestB3(t *testing.T) {
 	})
 
 	t.Run("extract", func(t *testing.T) {
-		os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "b3")
-		defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
-
 		headers := TextMapCarrier(map[string]string{
 			b3TraceIDHeader: "1",
 			b3SpanIDHeader:  "1",


### PR DESCRIPTION
These changes set B3 to be the default text map propagator and add OT baggage functionality.  Also took a stab at getting the tests to be runnable, as they are currently completely blocked by transitive vendoring issues w/ SFx's golib, which I'm tabling for a subsequent pass.