### PR TITLE
Update default tags with version and service name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-### Contributing
+# Contributing
 
 Pull requests for bug fixes are welcome, but before submitting new features or changes to current functionalities [open an issue](https://github.com/DataDog/dd-trace-go/issues/new)
 and discuss your ideas or propose the changes you wish to make. After a resolution is reached a PR can be submitted for review.
@@ -15,3 +15,9 @@ Fixes #113
 ```
 Please apply the same logic for Pull Requests, start with the package name, followed by a colon and a description of the change, just like
 the official [Go language](https://github.com/golang/go/pulls).
+
+
+## Cutting a new release
+
+In [tracing.go](./tracing/tracing.go), update the const `signalfxVersionValue` to reflect the release version. This value
+will be tagged in every span.

--- a/contrib/globalsign/mgo/mgo_test.go
+++ b/contrib/globalsign/mgo/mgo_test.go
@@ -475,12 +475,14 @@ func TestWithZipkin(t *testing.T) {
 		assert.Equal(ext.SpanKindClient, *span.Kind)
 
 		assert.Equal(span.Tags, map[string]string{
-			"component":     "mongodb",
-			"peer.hostname": "localhost:27017",
-			"db.instance":   "my_db",
-			"db.type":       "mongo",
-			"db.statement":  "collection.insert my_db",
-			"span.kind":     strings.ToLower(ext.SpanKindClient),
+			"component":                "mongodb",
+			"peer.hostname":            "localhost:27017",
+			"db.instance":              "my_db",
+			"db.type":                  "mongo",
+			"db.statement":             "collection.insert my_db",
+			"span.kind":                strings.ToLower(ext.SpanKindClient),
+			tracing.SignalfxLibraryKey: tracing.SignalfxLibraryValue,
+			tracing.SignalfxVersionKey: tracing.SignalfxVersionValue,
 		})
 		testutil.AssertSpanWithNoError(t, span)
 	})

--- a/contrib/internal/sqltest/sqltest.go
+++ b/contrib/internal/sqltest/sqltest.go
@@ -136,7 +136,7 @@ func testZipkin(cfg *Config) func(t *testing.T) {
 
 			assert.Equal("CLIENT", *span.Kind)
 			assert.Equal("Query", *span.Name)
-			assert.Equal(map[string]string{
+			testutil.AssertSpanWithTags (t, span,map[string]string{
 				"component":     "sql",
 				"db.type":       cfg.DriverName,
 				"db.instance":   cfg.DBName,
@@ -145,7 +145,7 @@ func testZipkin(cfg *Config) func(t *testing.T) {
 				"peer.hostname": "127.0.0.1",
 				"peer.port":     strconv.Itoa(cfg.DBPort),
 				"span.kind":     "client",
-			}, span.Tags)
+			})
 		})
 	}
 }

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -75,13 +75,13 @@ func TestRoundTripperZipkin(t *testing.T) {
 
 		assert.Equal("GET", *s1.Name)
 		assert.Equal("CLIENT", *s1.Kind)
-		assert.Equal(map[string]string{
-			"component":        "http",
-			"http.method":      "GET",
-			"http.url":         s.URL + "/query",
-			"span.kind":        "client",
-			"http.status_code": "200",
-		}, s1.Tags)
+		testutil.AssertSpanWithTags(t, s1, map[string]string{
+			"component":                "http",
+			"http.method":              "GET",
+			"http.url":                 s.URL + "/query",
+			"span.kind":                "client",
+			"http.status_code":         "200",
+		})
 		testutil.AssertSpanWithNoError(t, s1)
 	})
 
@@ -105,14 +105,14 @@ func TestRoundTripperZipkin(t *testing.T) {
 		tags := s1.Tags
 
 		assert.Equal("POST", *s1.Name)
-		assert.Equal(map[string]string{
-			"component":        "http",
-			"error":            "true",
-			"http.method":      "POST",
-			"http.url":         s.URL + "/?error=500",
-			"span.kind":        "client",
-			"http.status_code": "500",
-		}, tags)
+		testutil.AssertSpanWithTags(t, s1 ,map[string]string{
+			"component":                "http",
+			"error":                    "true",
+			"http.method":              "POST",
+			"http.url":                 s.URL + "/?error=500",
+			"span.kind":                "client",
+			"http.status_code":         "500",
+		})
 	})
 
 	t.Run("host connect error", func(t *testing.T) {
@@ -135,10 +135,10 @@ func TestRoundTripperZipkin(t *testing.T) {
 
 		assert.Equal("GET", *s0.Name)
 		testutil.AssertSpanWithTags(t, s0,map[string]string{
-			"component":   "http",
-			"http.method": "GET",
-			"http.url":    "http://localhost:1/query",
-			"span.kind":   "client",
+			"component":                "http",
+			"http.method":              "GET",
+			"http.url":                 "http://localhost:1/query",
+			"span.kind":                "client",
 		})
 		testutil.AssertSpanWithError(t, s0, testutil.ErrorAssertion{
 			KindEquals:      "*net.OpError",

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -102,7 +102,6 @@ func TestRoundTripperZipkin(t *testing.T) {
 		if assert.NotNil(s1.LocalEndpoint.ServiceName) {
 			assert.Equal("test-http-service", *s1.LocalEndpoint.ServiceName)
 		}
-		tags := s1.Tags
 
 		assert.Equal("POST", *s1.Name)
 		testutil.AssertSpanWithTags(t, s1 ,map[string]string{

--- a/tracing/opentracing_test.go
+++ b/tracing/opentracing_test.go
@@ -112,9 +112,11 @@ func TestWithGlobalTags(t *testing.T) {
 	spans := zipkin.WaitForSpans(t, 1)
 
 	tags := spans[0].Tags
-	require.Equal(2, len(tags))
-	require.Equal("value",tags["test"], )
-	require.Equal("1234", tags["abc-test"])
+	require.Equal(4, len(tags))
+	assert.Equal(t, "value",tags["test"], )
+	assert.Equal(t, "1234", tags["abc-test"])
+	assert.Equal(t, signalfxVersionValue, tags[signalfxVersionKey])
+	assert.Equal(t, signalfxLibraryValue,tags[signalfxLibraryKey])
 }
 
 func TestEnvironmentVariables(t *testing.T) {
@@ -143,10 +145,12 @@ func TestEnvironmentVariables(t *testing.T) {
 	assert.Equal("MyService", *spans[0].LocalEndpoint.ServiceName)
 
 	tags := spans[0].Tags
-	require.Equal(5, len(tags))
+	require.Equal(7, len(tags))
 	assert.Equal("value",tags["test"])
 	assert.Equal("1234", tags["abc-test"])
 	assert.Equal("b", tags["a"])
 	assert.Equal("d", tags["c"])
 	assert.Equal("", tags["bob"])
+	assert.Equal(signalfxVersionValue, tags[signalfxVersionKey])
+	assert.Equal(signalfxLibraryValue,tags[signalfxLibraryKey])
 }

--- a/tracing/opentracing_test.go
+++ b/tracing/opentracing_test.go
@@ -115,8 +115,8 @@ func TestWithGlobalTags(t *testing.T) {
 	require.Equal(4, len(tags))
 	assert.Equal(t, "value",tags["test"], )
 	assert.Equal(t, "1234", tags["abc-test"])
-	assert.Equal(t, signalfxVersionValue, tags[signalfxVersionKey])
-	assert.Equal(t, signalfxLibraryValue,tags[signalfxLibraryKey])
+	assert.Equal(t, SignalfxVersionValue, tags[SignalfxVersionKey])
+	assert.Equal(t, SignalfxLibraryKey, tags[SignalfxLibraryKey])
 }
 
 func TestEnvironmentVariables(t *testing.T) {
@@ -151,6 +151,6 @@ func TestEnvironmentVariables(t *testing.T) {
 	assert.Equal("b", tags["a"])
 	assert.Equal("d", tags["c"])
 	assert.Equal("", tags["bob"])
-	assert.Equal(signalfxVersionValue, tags[signalfxVersionKey])
-	assert.Equal(signalfxLibraryValue,tags[signalfxLibraryKey])
+	assert.Equal(SignalfxVersionValue, tags[SignalfxVersionKey])
+	assert.Equal(SignalfxLibraryKey, tags[SignalfxLibraryKey])
 }

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -57,7 +57,7 @@ func envDefaultAndGlobalTags() []tracer.StartOption {
 	var globalTags []tracer.StartOption
 
 	// Add the default Library and Version tags.
-	defaultLibraryTag := tracer.WithGlobalTag(SignalfxLibraryKey, SignalfxLibraryKey)
+	defaultLibraryTag := tracer.WithGlobalTag(SignalfxLibraryKey, SignalfxLibraryValue)
 	globalTags = append(globalTags, defaultLibraryTag)
 	defaultVersionTag := tracer.WithGlobalTag(SignalfxVersionKey, SignalfxVersionValue)
 	globalTags = append(globalTags, defaultVersionTag)

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -15,11 +15,11 @@ const (
 	signalfxSpanTags    = "SIGNALFX_SPAN_TAGS"
 
 	// Set of default keys added to every span.
-	signalfxLibraryKey  = "signalfx.tracing.library"
-	signalfxLibraryValue= "go.tracing"
+	SignalfxLibraryKey  = "signalfx.tracing.library"
+	SignalfxLibraryValue= "go.tracing"
 	// When cutting a new release, update the version value.
-	signalfxVersionKey  = "signalfx.tracing.version"
-	signalfxVersionValue = "v1.1.0"
+	SignalfxVersionKey   = "signalfx.tracing.version"
+	SignalfxVersionValue = "v1.1.0"
 )
 
 var defaults = map[string]string{
@@ -57,9 +57,9 @@ func envDefaultAndGlobalTags() []tracer.StartOption {
 	var globalTags []tracer.StartOption
 
 	// Add the default Library and Version tags.
-	defaultLibraryTag := tracer.WithGlobalTag(signalfxLibraryKey, signalfxLibraryValue)
+	defaultLibraryTag := tracer.WithGlobalTag(SignalfxLibraryKey, SignalfxLibraryKey)
 	globalTags = append(globalTags, defaultLibraryTag)
-	defaultVersionTag := tracer.WithGlobalTag(signalfxVersionKey, signalfxVersionValue)
+	defaultVersionTag := tracer.WithGlobalTag(SignalfxVersionKey, SignalfxVersionValue)
 	globalTags = append(globalTags, defaultVersionTag)
 
 	// Add environment tags if they are passed in.


### PR DESCRIPTION
- Library( `signalfx.tracing.library`: `go.tracing`)  and Version (`signalfx.tracing.version`: `<release number>`) tags are now set for all spans.
- Updated contributing.md to reference keeping release version in sync with library version.
- Update default service name to be `unnamed-go-service` to match other libraries default service name.