### PR TITLE
Optionally pass trace context in http response via Server-Timing.

### DIFF
--- a/contrib/internal/httputil/trace.go
+++ b/contrib/internal/httputil/trace.go
@@ -48,6 +48,7 @@ func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, servi
 			w.Header().Add("Access-Control-Expose-Headers", "Server-Timing")
 			w.Header().Add("Server-Timing", traceParent)
 		}
+	}
 
 	h.ServeHTTP(w, r.WithContext(ctx))
 }

--- a/contrib/internal/httputil/trace.go
+++ b/contrib/internal/httputil/trace.go
@@ -44,12 +44,10 @@ func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, servi
 	w = wrapResponseWriter(w, span)
 
 	if strings.EqualFold("true", os.Getenv("SIGNALFX_SERVER_TIMING_CONTEXT")) {
-		traceParent,ok := tracer.FormatAsTraceParent(span.Context())
-		if ok {
+		if traceParent, ok := tracer.FormatAsTraceParent(span.Context()); ok {
 			w.Header().Add("Access-Control-Expose-Headers", "Server-Timing")
 			w.Header().Add("Server-Timing", traceParent)
 		}
-	}
 
 	h.ServeHTTP(w, r.WithContext(ctx))
 }

--- a/ddtrace/tracer/traceparent.go
+++ b/ddtrace/tracer/traceparent.go
@@ -1,0 +1,15 @@
+package tracer
+
+import (
+	"fmt"
+	"github.com/signalfx/signalfx-go-tracing/ddtrace"
+)
+
+func FormatAsTraceParent(context ddtrace.SpanContext) (string,bool) {
+	ctx, ok := context.(*spanContext)
+	if !ok || ctx.traceID == 0 || ctx.spanID == 0 {
+		return "",false
+	}
+	answer := fmt.Sprintf("traceparent;desc=\"00-%032x-%016x-01\"", ctx.traceID, ctx.spanID)
+	return answer,true
+}

--- a/ddtrace/tracer/traceparent_test.go
+++ b/ddtrace/tracer/traceparent_test.go
@@ -1,0 +1,19 @@
+package tracer
+
+import (
+	"testing"
+	"regexp"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTraceParent(t *testing.T) {                
+	tracer := newTracer()
+	span := tracer.StartSpan("web.request").(*span)
+	traceParent,ok := FormatAsTraceParent(span.Context())
+
+	assert := assert.New(t)
+	assert.True(ok)
+	matched,_ := regexp.MatchString("^traceparent;desc=\"00-[0-9a-f]{32}-[0-9a-f]{16}-01\"$", traceParent)
+	assert.True(matched)
+}


### PR DESCRIPTION
If SIGNALFX_SERVER_TIMING_CONTEXT is turned on, pass trace context
in traceparent form over a Server-Timing header.

https://www.w3.org/TR/server-timing/
https://www.w3.org/TR/trace-context/#traceparent-header