### PR TITLE
Span.Tracer() method now returns the opentracing global tracer

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -82,7 +82,7 @@ func (s *span) LogKV(alternatingKeyValues ...interface{}) {
 
 // Tracer returns the global tracer
 func (s *span) Tracer() opentracing.Tracer {
-	return ddtrace.GetGlobalTracer().(opentracing.Tracer)
+	return opentracing.GlobalTracer()
 }
 
 // LogFields field to span


### PR DESCRIPTION
After calling tracing.Start(), the same internal tracer is registered as
the global opentracing tracer as well so we can directly return it.