### PR TITLE
Return opentracer from span tracer method

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,7 +39,7 @@
 
 [[constraint]]
   name = "github.com/opentracing/opentracing-go"
-  version = "1.1.0"
+  version = "1.2.0"
 
 [[constraint]]
   name = "github.com/signalfx/golib"

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -17,7 +17,6 @@ package opentracer
 import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/signalfx/signalfx-go-tracing/ddtrace"
-	"github.com/signalfx/signalfx-go-tracing/ddtrace/tracer"
 )
 
 // New creates, instantiates and returns an Opentracing compatible version of the
@@ -37,15 +36,15 @@ func (t *opentracer) StartSpan(operationName string, options ...opentracing.Star
 	for _, o := range options {
 		o.Apply(&sso)
 	}
-	opts := []ddtrace.StartSpanOption{tracer.StartTime(sso.StartTime)}
+	opts := []ddtrace.StartSpanOption{ddtrace.WithStartTime(sso.StartTime)}
 	for _, ref := range sso.References {
 		if v, ok := ref.ReferencedContext.(ddtrace.SpanContext); ok && ref.Type == opentracing.ChildOfRef {
-			opts = append(opts, tracer.ChildOf(v))
+			opts = append(opts, ddtrace.WithChildOf(v))
 			break // can only have one parent
 		}
 	}
 	for k, v := range sso.Tags {
-		opts = append(opts, tracer.Tag(k, v))
+		opts = append(opts, ddtrace.WithTag(k, v))
 	}
 	return t.Tracer.StartSpan(operationName, opts...)
 }

--- a/ddtrace/options.go
+++ b/ddtrace/options.go
@@ -1,0 +1,37 @@
+// Package ddtrace contains the interfaces that specify the implementations of Datadog's
+// tracing library, as well as a set of sub-packages containing various implementations:
+// our native implementation ("tracer"), a wrapper that can be used with Opentracing
+// ("opentracer") and a mock tracer to be used for testing ("mocktracer"). Additionally,
+// package "ext" provides a set of tag names and values specific to Datadog's APM product.
+//
+// To get started, visit the documentation for any of the packages you'd like to begin
+// with by accessing the subdirectories of this package: https://godoc.org/github.com/signalfx/signalfx-go-tracing/ddtrace#pkg-subdirectories.
+package ddtrace // import "github.com/signalfx/signalfx-go-tracing/ddtrace"
+
+import "time"
+
+// WithTag sets the given key/value pair as a tag on the started Span.
+func WithTag(k string, v interface{}) StartSpanOption {
+	return func(cfg *StartSpanConfig) {
+		if cfg.Tags == nil {
+			cfg.Tags = map[string]interface{}{}
+		}
+		cfg.Tags[k] = v
+	}
+}
+
+// WithChildOf tells StartSpan to use the given span context as a parent for the
+// created span.
+func WithChildOf(ctx SpanContext) StartSpanOption {
+	return func(cfg *StartSpanConfig) {
+		cfg.Parent = ctx
+	}
+}
+
+// WithStartTime sets a custom time as the start time for the created span. By
+// default a span is started using the creation time.
+func WithStartTime(t time.Time) StartSpanOption {
+	return func(cfg *StartSpanConfig) {
+		cfg.StartTime = t
+	}
+}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -177,12 +177,7 @@ type StartSpanOption = ddtrace.StartSpanOption
 
 // Tag sets the given key/value pair as a tag on the started Span.
 func Tag(k string, v interface{}) StartSpanOption {
-	return func(cfg *ddtrace.StartSpanConfig) {
-		if cfg.Tags == nil {
-			cfg.Tags = map[string]interface{}{}
-		}
-		cfg.Tags[k] = v
-	}
+	return ddtrace.WithTag(k, v)
 }
 
 // ServiceName sets the given service name on the started span. For example "http.server".
@@ -214,17 +209,13 @@ func WithSpanID(id uint64) StartSpanOption {
 // ChildOf tells StartSpan to use the given span context as a parent for the
 // created span.
 func ChildOf(ctx ddtrace.SpanContext) StartSpanOption {
-	return func(cfg *ddtrace.StartSpanConfig) {
-		cfg.Parent = ctx
-	}
+	return ddtrace.WithChildOf(ctx)
 }
 
 // StartTime sets a custom time as the start time for the created span. By
 // default a span is started using the creation time.
 func StartTime(t time.Time) StartSpanOption {
-	return func(cfg *ddtrace.StartSpanConfig) {
-		cfg.StartTime = t
-	}
+	return ddtrace.WithStartTime(t)
 }
 
 // FinishOption is a configuration option for FinishSpan. It is aliased in order

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -82,7 +82,7 @@ func (s *span) LogKV(alternatingKeyValues ...interface{}) {
 
 // Tracer returns the global tracer
 func (s *span) Tracer() opentracing.Tracer {
-	return ddtrace.GetGlobalTracer().(opentracing.Tracer)
+	return opentracing.GlobalTracer()
 }
 
 // LogFields field to span

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/signalfx/signalfx-go-tracing/ddtrace"
 	"github.com/signalfx/signalfx-go-tracing/ddtrace/ext"
+	"github.com/signalfx/signalfx-go-tracing/ddtrace/opentracer"
 )
 
 type (
@@ -82,7 +83,9 @@ func (s *span) LogKV(alternatingKeyValues ...interface{}) {
 
 // Tracer returns the global tracer
 func (s *span) Tracer() opentracing.Tracer {
-	return opentracing.GlobalTracer()
+	// return ddtrace.GetGlobalTracer() wrapped to make it
+	// a compatible opentracing Tracer
+	return opentracer.New()
 }
 
 // LogFields field to span


### PR DESCRIPTION
    Span.Tracer() method now returns a valid opentracing.Tracer
    implementation

    Span.Tracer() now returns the opentracer wrapped version of the global
    SFX tracer to make it compatible with the opentracing Tracer.

    This commit moves out some options from ddtrace/tracer to ddtrace in
    order to avoid circular dependency between ddtrace/tracer and opentracer
    packages