### PR TITLE
Added support for echo/v4

### DIFF
--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -1,4 +1,4 @@
-// Package echo provides functions to trace the labstack/echo package (https://github.com/labstack/echo).
+// Package echo provides functions to trace the labstack/echo/v4 package (https://github.com/labstack/echo).
 package echo
 
 import (

--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -1,0 +1,55 @@
+// Package echo provides functions to trace the labstack/echo package (https://github.com/labstack/echo).
+package echo
+
+import (
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/signalfx/signalfx-go-tracing/ddtrace"
+	"github.com/signalfx/signalfx-go-tracing/ddtrace/ext"
+	"github.com/signalfx/signalfx-go-tracing/ddtrace/tracer"
+	"github.com/signalfx/signalfx-go-tracing/internal/utils"
+)
+
+// Middleware returns echo middleware which will trace incoming requests.
+func Middleware(opts ...Option) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		cfg := new(config)
+		defaults(cfg)
+		for _, fn := range opts {
+			fn(cfg)
+		}
+		return func(c echo.Context) error {
+			request := c.Request()
+			operationName := c.Path()
+			opts := []ddtrace.StartSpanOption{
+				tracer.ServiceName(cfg.serviceName),
+				tracer.ResourceName(operationName),
+				tracer.SpanType(ext.SpanTypeEcho),
+				tracer.Tag(ext.SpanKind, ext.SpanKindServer),
+				tracer.Tag(ext.HTTPMethod, request.Method),
+				tracer.Tag(ext.HTTPURL, utils.GetURL(request)),
+			}
+
+			if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(request.Header)); err == nil {
+				opts = append(opts, tracer.ChildOf(spanctx))
+			}
+			span, ctx := tracer.StartSpanFromContext(request.Context(), operationName, opts...)
+			defer span.Finish()
+
+			// pass the span through the request context
+			c.SetRequest(request.WithContext(ctx))
+
+			// serve the request to the next middleware
+			err := next(c)
+
+			span.SetTag(ext.HTTPCode, strconv.Itoa(c.Response().Status))
+
+			if err != nil {
+				span.SetTag(ext.Error, err)
+			}
+			return err
+		}
+	}
+}

--- a/contrib/labstack/echo.v4/echotrace_test.go
+++ b/contrib/labstack/echo.v4/echotrace_test.go
@@ -1,0 +1,262 @@
+package echo
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/signalfx/signalfx-go-tracing/contrib/internal/testutil"
+	"github.com/signalfx/signalfx-go-tracing/ddtrace/ext"
+	"github.com/signalfx/signalfx-go-tracing/ddtrace/mocktracer"
+	"github.com/signalfx/signalfx-go-tracing/ddtrace/tracer"
+	"github.com/signalfx/signalfx-go-tracing/tracing"
+	"github.com/signalfx/signalfx-go-tracing/zipkinserver"
+)
+
+func TestChildSpan(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	var called, traced bool
+
+	router := echo.New()
+	router.Use(Middleware(WithServiceName("foobar")))
+	router.GET("/user/:id", func(c echo.Context) error {
+		called = true
+		_, traced = tracer.SpanFromContext(c.Request().Context())
+		return c.NoContent(200)
+	})
+
+	r := httptest.NewRequest("GET", "/user/123", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	// verify traces look good
+	assert.True(called)
+	assert.True(traced)
+}
+
+func TestTrace200(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	var called, traced bool
+
+	router := echo.New()
+	router.Use(Middleware(WithServiceName("foobar")))
+	router.GET("/user/:id", func(c echo.Context) error {
+		called = true
+		var span tracer.Span
+		span, traced = tracer.SpanFromContext(c.Request().Context())
+
+		// we patch the span on the request context.
+		span.SetTag("test.echo", "echony")
+		assert.Equal(span.(mocktracer.Span).Tag(ext.ServiceName), "foobar")
+		return c.NoContent(200)
+	})
+
+	root := tracer.StartSpan("root")
+	r := httptest.NewRequest("GET", "/user/123", nil)
+	err := tracer.Inject(root.Context(), tracer.HTTPHeadersCarrier(r.Header))
+	assert.Nil(err)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	// verify traces look good
+	assert.True(called)
+	assert.True(traced)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+
+	span := spans[0]
+	assert.Equal("/user/:id", span.OperationName())
+	assert.Equal(ext.SpanTypeEcho, span.Tag(ext.SpanType))
+	assert.Equal("foobar", span.Tag(ext.ServiceName))
+	assert.Equal("echony", span.Tag("test.echo"))
+	assert.Contains(span.Tag(ext.ResourceName), "/user/:id")
+	assert.Equal("200", span.Tag(ext.HTTPCode))
+	assert.Equal("GET", span.Tag(ext.HTTPMethod))
+	//assert.Equal(root.Context().SpanID(), span.ParentID())
+
+	assert.Equal("http://example.com/user/123", span.Tag(ext.HTTPURL))
+}
+
+func TestError(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	var called, traced bool
+
+	// setup
+	router := echo.New()
+	router.Use(Middleware(WithServiceName("foobar")))
+	wantErr := errors.New("oh no")
+
+	// a handler with an error and make the requests
+	router.GET("/err", func(c echo.Context) error {
+		_, traced = tracer.SpanFromContext(c.Request().Context())
+		called = true
+
+		err := wantErr
+		c.Error(err)
+		return err
+	})
+	r := httptest.NewRequest("GET", "/err", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	// verify the errors and status are correct
+	assert.True(called)
+	assert.True(traced)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+
+	span := spans[0]
+	assert.Equal("/err", span.OperationName())
+	assert.Equal("foobar", span.Tag(ext.ServiceName))
+	assert.Equal("500", span.Tag(ext.HTTPCode))
+	assert.Equal(wantErr.Error(), span.Tag(ext.Error).(error).Error())
+}
+
+func TestGetSpanNotInstrumented(t *testing.T) {
+	assert := assert.New(t)
+	router := echo.New()
+	var called, traced bool
+
+	router.GET("/ping", func(c echo.Context) error {
+		// Assert we don't have a span on the context.
+		called = true
+		_, traced = tracer.SpanFromContext(c.Request().Context())
+		return c.NoContent(200)
+	})
+
+	r := httptest.NewRequest("GET", "/ping", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+	assert.True(called)
+	assert.False(traced)
+}
+
+func TestEchoTracer200Zipkin(t *testing.T) {
+	zipkin := zipkinserver.Start()
+	defer zipkin.Stop()
+
+	tracing.Start(tracing.WithEndpointURL(zipkin.URL()), tracing.WithServiceName("test-echo"))
+	defer tracing.Stop()
+
+	e := echo.New()
+	e.Use(Middleware(WithServiceName("test-echo")))
+	e.GET("/mock200", mock200)
+
+	r := httptest.NewRequest("GET", "/mock200", nil)
+	w := httptest.NewRecorder()
+	e.ServeHTTP(w, r)
+
+	tracer.ForceFlush()
+	spans := zipkin.WaitForSpans(t, 1)
+	span := spans[0]
+
+	assert.Equal(t, *span.Name, "/mock200")
+	assert.Equal(t, *span.Kind, "SERVER")
+	testutil.AssertSpanWithTags(t, span, map[string]string{
+		"component":        "echo",
+		"http.url":         "http://example.com/mock200",
+		"http.method":      "GET",
+		"http.status_code": "200",
+		"span.kind":        "server",
+	})
+	testutil.AssertSpanWithNoError(t, span)
+}
+
+func TestEchoTracer401Zipkin(t *testing.T) {
+	zipkin := zipkinserver.Start()
+	defer zipkin.Stop()
+
+	tracing.Start(tracing.WithEndpointURL(zipkin.URL()), tracing.WithServiceName("test-echo"))
+	defer tracing.Stop()
+
+	e := echo.New()
+	e.Use(Middleware(WithServiceName("test-echo")))
+	e.POST("/mock401", mock401)
+
+	r := httptest.NewRequest("POST", "/mock401", nil)
+	w := httptest.NewRecorder()
+	e.ServeHTTP(w, r)
+
+	tracer.ForceFlush()
+	spans := zipkin.WaitForSpans(t, 1)
+	span := spans[0]
+
+	assert.Equal(t, *span.Name, "/mock401")
+	assert.Equal(t, *span.Kind, "SERVER")
+	testutil.AssertSpanWithTags(t, span, map[string]string{
+		"component":        "echo",
+		"http.url":         "http://example.com/mock401",
+		"http.method":      "POST",
+		"http.status_code": "401",
+		"span.kind":        "server",
+	})
+	testutil.AssertSpanWithNoError(t, span)
+}
+
+func TestEchoTracer500Zipkin(t *testing.T) {
+	zipkin := zipkinserver.Start()
+	defer zipkin.Stop()
+
+	tracing.Start(tracing.WithEndpointURL(zipkin.URL()), tracing.WithServiceName("test-echo"))
+	defer tracing.Stop()
+
+	e := echo.New()
+	e.Use(Middleware(WithServiceName("test-echo")))
+	e.POST("/mock500", mock500)
+
+	r := httptest.NewRequest("POST", "/mock500", nil)
+	w := httptest.NewRecorder()
+	e.ServeHTTP(w, r)
+
+	tracer.ForceFlush()
+	spans := zipkin.WaitForSpans(t, 1)
+	span := spans[0]
+
+	assert.Equal(t, *span.Kind, "SERVER")
+	assert.Equal(t, *span.Name, "/mock500")
+
+	testutil.AssertSpanWithTags(t, span, map[string]string{
+		"component":        "echo",
+		"http.url":         "http://example.com/mock500",
+		"http.method":      "POST",
+		"http.status_code": "500",
+		"span.kind":        "server",
+		ext.Error:          "true",
+		ext.ErrorKind:      "*echo.HTTPError",
+	})
+
+	testutil.AssertSpanWithError(t, span, testutil.ErrorAssertion{
+		KindEquals:      "*echo.HTTPError",
+		MessageContains: "Internal Server Error",
+		ObjectContains:  "&echo.HTTPError",
+		StackContains:   []string{"goroutine"},
+		StackMinLength:  50,
+	})
+}
+
+func mock200(c echo.Context) error {
+	return c.JSON(http.StatusOK, "")
+}
+
+func mock401(c echo.Context) error {
+	return c.JSON(http.StatusUnauthorized, "")
+}
+
+func mock500(c echo.Context) error {
+	err := &echo.HTTPError{Code: http.StatusInternalServerError, Message: "Internal Server Error"}
+	c.Error(err)
+	return err
+}

--- a/contrib/labstack/echo.v4/example_test.go
+++ b/contrib/labstack/echo.v4/example_test.go
@@ -1,0 +1,45 @@
+package echo
+
+import (
+	"github.com/labstack/echo/v4"
+
+	"github.com/signalfx/signalfx-go-tracing/ddtrace/tracer"
+)
+
+// To start tracing requests, add the trace middleware to your echo router.
+func Example() {
+	r := echo.New()
+
+	// Use the tracer middleware with your desired service name.
+	r.Use(Middleware(WithServiceName("my-web-app")))
+
+	// Set up an endpoint.
+	r.GET("/hello", func(c echo.Context) error {
+		return c.String(200, "hello world!")
+	})
+
+	// ...and listen for incoming requests
+	r.Start(":8080")
+}
+
+// An example illustrating tracing a child operation within the main context.
+func Example_spanFromContext() {
+	// Create a new instance of echo
+	r := echo.New()
+
+	// Use the tracer middleware with your desired service name.
+	r.Use(Middleware(WithServiceName("image-encoder")))
+
+	// Set up some endpoints.
+	r.GET("/image/encode", func(c echo.Context) error {
+		// create a child span to track an operation
+		span, _ := tracer.StartSpanFromContext(c.Request().Context(), "image.encode")
+
+		// encode an image ...
+
+		// finish the child span
+		span.Finish()
+
+		return c.String(200, "ok!")
+	})
+}

--- a/contrib/labstack/echo.v4/option.go
+++ b/contrib/labstack/echo.v4/option.go
@@ -1,0 +1,19 @@
+package echo
+
+type config struct {
+	serviceName string
+}
+
+// Option represents an option that can be passed to Middleware.
+type Option func(*config)
+
+func defaults(cfg *config) {
+	cfg.serviceName = "echo"
+}
+
+// WithServiceName sets the given service name for the system.
+func WithServiceName(name string) Option {
+	return func(cfg *config) {
+		cfg.serviceName = name
+	}
+}


### PR DESCRIPTION
In order to support echo/v4, the instrumentation needed to import echo
from the updated v4 path and also provide an alternate import path for
itself.

When using echo/v4, users must import the instrumentation middleware
from

	"github.com/signalfx/signalfx-go-tracing/contrib/labstack/echo.v4"

instead of

	"github.com/signalfx/signalfx-go-tracing/contrib/labstack/echo"