### PR TITLE
Don't set span.kind tag on Zipkin encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 go.mod
 go.sum
+contrib/google.golang.org/grpc.v12/grpcv12_go.mod
+contrib/google.golang.org/grpc.v12/grpcv12_go.sum
 
 # go
 bin/

--- a/contrib/gin-gonic/gin/gintrace_test.go
+++ b/contrib/gin-gonic/gin/gintrace_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"html/template"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/signalfx/signalfx-go-tracing/contrib/internal/testutil"
@@ -305,7 +304,6 @@ func TestWithZipkin(t *testing.T) {
 			"http.method":      "GET",
 			"http.status_code": "200",
 			"http.url":         "http://example.com/successful",
-			"span.kind":        strings.ToLower(ext.SpanKindServer),
 		})
 		testutil.AssertSpanWithNoError(t, span)
 	})
@@ -333,7 +331,6 @@ func TestWithZipkin(t *testing.T) {
 			"http.method":      "POST",
 			"http.status_code": "400",
 			"http.url":         "http://example.com/unsuccessful",
-			"span.kind":        strings.ToLower(ext.SpanKindServer),
 		})
 		testutil.AssertSpanWithError(t, span, testutil.ErrorAssertion{
 			KindEquals:      "*gin.Error",

--- a/contrib/globalsign/mgo/mgo_test.go
+++ b/contrib/globalsign/mgo/mgo_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/globalsign/mgo"
@@ -484,7 +483,6 @@ func TestWithZipkin(t *testing.T) {
 			"db.instance":   "my_db",
 			"db.type":       "mongo",
 			"db.statement":  "collection.insert my_db",
-			"span.kind":     strings.ToLower(ext.SpanKindClient),
 		})
 		testutil.AssertSpanWithNoError(t, span)
 	})
@@ -521,7 +519,6 @@ func TestWithZipkin(t *testing.T) {
 			"db.instance":   "my_db",
 			"db.type":       "mongo",
 			"db.statement":  "collection.insert my_db",
-			"span.kind":     strings.ToLower(ext.SpanKindClient),
 		})
 
 		testutil.AssertSpanWithError(t, span, testutil.ErrorAssertion{

--- a/contrib/internal/sqltest/sqltest.go
+++ b/contrib/internal/sqltest/sqltest.go
@@ -101,7 +101,6 @@ func testZipkin(cfg *Config) func(t *testing.T) {
 				"db.user":       cfg.DBUser,
 				"peer.hostname": "127.0.0.1",
 				"peer.port":     strconv.Itoa(cfg.DBPort),
-				"span.kind":     "client",
 			})
 
 			ea := testutil.ErrorAssertion{
@@ -148,7 +147,6 @@ func testZipkin(cfg *Config) func(t *testing.T) {
 				"db.user":       cfg.DBUser,
 				"peer.hostname": "127.0.0.1",
 				"peer.port":     strconv.Itoa(cfg.DBPort),
-				"span.kind":     "client",
 			}, span.Tags)
 		})
 	}

--- a/contrib/labstack/echo.v4/echotrace_test.go
+++ b/contrib/labstack/echo.v4/echotrace_test.go
@@ -170,7 +170,6 @@ func TestEchoTracer200Zipkin(t *testing.T) {
 		"http.url":         "http://example.com/mock200",
 		"http.method":      "GET",
 		"http.status_code": "200",
-		"span.kind":        "server",
 	})
 	testutil.AssertSpanWithNoError(t, span)
 }
@@ -201,7 +200,6 @@ func TestEchoTracer401Zipkin(t *testing.T) {
 		"http.url":         "http://example.com/mock401",
 		"http.method":      "POST",
 		"http.status_code": "401",
-		"span.kind":        "server",
 	})
 	testutil.AssertSpanWithNoError(t, span)
 }
@@ -233,7 +231,6 @@ func TestEchoTracer500Zipkin(t *testing.T) {
 		"http.url":         "http://example.com/mock500",
 		"http.method":      "POST",
 		"http.status_code": "500",
-		"span.kind":        "server",
 		ext.Error:          "true",
 		ext.ErrorKind:      "*echo.HTTPError",
 	})

--- a/contrib/labstack/echo/echotrace_test.go
+++ b/contrib/labstack/echo/echotrace_test.go
@@ -170,7 +170,6 @@ func TestEchoTracer200Zipkin(t *testing.T) {
 		"http.url":         "http://example.com/mock200",
 		"http.method":      "GET",
 		"http.status_code": "200",
-		"span.kind":        "server",
 	})
 	testutil.AssertSpanWithNoError(t, span)
 }
@@ -201,7 +200,6 @@ func TestEchoTracer401Zipkin(t *testing.T) {
 		"http.url":         "http://example.com/mock401",
 		"http.method":      "POST",
 		"http.status_code": "401",
-		"span.kind":        "server",
 	})
 	testutil.AssertSpanWithNoError(t, span)
 }
@@ -233,7 +231,6 @@ func TestEchoTracer500Zipkin(t *testing.T) {
 		"http.url":         "http://example.com/mock500",
 		"http.method":      "POST",
 		"http.status_code": "500",
-		"span.kind":        "server",
 		ext.Error:            "true",
 		ext.ErrorKind: "*echo.HTTPError",
 	})

--- a/contrib/mongodb/mongo-go-driver/mongo/mongo_test.go
+++ b/contrib/mongodb/mongo-go-driver/mongo/mongo_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/signalfx/signalfx-go-tracing/contrib/internal/testutil"
 	"io"
 	"net"
-	"strings"
 	"testing"
 	"time"
 
@@ -118,7 +117,6 @@ func TestWithZipkin(t *testing.T) {
 		assert.Equal(port, span.Tags[ext.PeerPort])
 		assert.Equal("test-database", span.Tags[ext.DBInstance])
 		assert.Equal("mongo", span.Tags[ext.DBType])
-		assert.Equal(strings.ToLower(ext.SpanKindClient), span.Tags[ext.SpanKind])
 		assert.Contains(span.Tags[ext.DBStatement], `"test-item":"test-value"`)
 
 		testutil.AssertSpanWithNoError(t, span)

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -45,7 +45,6 @@ func TestHttpTracer200Zipkin(t *testing.T) {
 		"http.url":         "http://example.com/200",
 		"http.method":      "GET",
 		"http.status_code": "200",
-		"span.kind":        "server",
 	})
 	testutil.AssertSpanWithNoError(t, span)
 }
@@ -80,7 +79,6 @@ func TestHttpTracer500Zipkin(t *testing.T) {
 		"http.url":         "http://example.com/500",
 		"http.method":      "GET",
 		"http.status_code": "500",
-		"span.kind":        "server",
 	})
 	testutil.AssertSpanWithError(t, span, testutil.ErrorAssertion{
 		KindEquals:      "*errors.errorString",

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -84,7 +84,6 @@ func TestRoundTripperZipkin(t *testing.T) {
 			"component":        "http",
 			"http.method":      "GET",
 			"http.url":         s.URL + "/query",
-			"span.kind":        "client",
 			"http.status_code": "200",
 		}, s1.Tags)
 		testutil.AssertSpanWithNoError(t, s1)
@@ -110,12 +109,12 @@ func TestRoundTripperZipkin(t *testing.T) {
 		tags := s1.Tags
 
 		assert.Equal("POST", *s1.Name)
+		assert.Equal("CLIENT", *s1.Kind)
 		assert.Equal(map[string]string{
 			"component":        "http",
 			"error":            "true",
 			"http.method":      "POST",
 			"http.url":         s.URL + "/?error=500",
-			"span.kind":        "client",
 			"http.status_code": "500",
 		}, tags)
 	})
@@ -139,11 +138,11 @@ func TestRoundTripperZipkin(t *testing.T) {
 		}
 
 		assert.Equal("GET", *s0.Name)
+		assert.Equal("CLIENT", *s0.Kind)
 		testutil.AssertSpanWithTags(t, s0, map[string]string{
 			"component":   "http",
 			"http.method": "GET",
 			"http.url":    "http://localhost:1/query",
-			"span.kind":   "client",
 		})
 		testutil.AssertSpanWithError(t, s0, testutil.ErrorAssertion{
 			KindEquals:      "*net.OpError",

--- a/ddtrace/tracer/zipkinpayload.go
+++ b/ddtrace/tracer/zipkinpayload.go
@@ -125,10 +125,6 @@ func (p *zipkinPayload) convertSpans(spans spanList) []*traceformat.Span {
 			tags["component"] = span.Type
 		}
 
-		if sfxSpan.Kind != nil && *sfxSpan.Kind != "" {
-			tags["span.kind"] = strings.ToLower(*sfxSpan.Kind)
-		}
-
 		formatTags(tags)
 		sfxSpan.Tags = tags
 
@@ -159,7 +155,7 @@ func convertLogs(logs []*logFields) []*sfxtrace.Annotation {
 
 func deriveKind(s *span) *string {
 	if kind, ok := s.Meta[spanKind]; ok {
-		return pointer.String(kind)
+		return pointer.String(strings.ToUpper(kind))
 	}
 
 	switch s.Type {
@@ -168,7 +164,7 @@ func deriveKind(s *span) *string {
 	case ext.SpanTypeWeb:
 		return pointer.String(spanKindServer)
 	case ext.SpanTypeMongoDB:
-    return pointer.String(spanKindClient)
+		return pointer.String(spanKindClient)
 	case ext.SpanTypeSQL:
 		return pointer.String(spanKindClient)
 	}


### PR DESCRIPTION
These changes ensure that redundant span.kind tag isn't set and that actual kind is uppercase when determined by this tag value.

Also ran go fmt and ignoring workaround ci go mod path.