### PR TITLE
Added support for SIGNALFX_RECORDED_VALUE_MAX_LENGTH

### DIFF
--- a/contrib/garyburd/redigo/redigo.go
+++ b/contrib/garyburd/redigo/redigo.go
@@ -121,6 +121,10 @@ func (tc Conn) Do(commandName string, args ...interface{}) (reply interface{}, e
 		}
 	}
 
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	span := tc.newChildSpan(ctx)
 	defer func() {
 		span.FinishWithOptionsExt(tracer.WithError(err))

--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -109,6 +109,9 @@ func (c *Pipeliner) execWithContext(ctx context.Context) ([]redis.Cmder, error) 
 	if rate := p.config.analyticsRate; rate > 0 {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	span, _ := tracer.StartSpanFromContext(ctx, "redis.command", opts...)
 	cmds, err := c.Pipeliner.Exec()
 	span.SetTag(ext.ResourceName, commandsToString(cmds))
@@ -174,6 +177,9 @@ func createWrapperFromClient(tc *Client) func(oldProcess func(cmd redis.Cmder) e
 			}
 			if rate := p.config.analyticsRate; rate > 0 {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+			}
+			if ctx == nil {
+				ctx = context.Background()
 			}
 			span, _ := tracer.StartSpanFromContext(ctx, "redis.command", opts...)
 			err := oldProcess(cmd)

--- a/contrib/gomodule/redigo/redigo.go
+++ b/contrib/gomodule/redigo/redigo.go
@@ -120,6 +120,10 @@ func (tc Conn) Do(commandName string, args ...interface{}) (reply interface{}, e
 		}
 	}
 
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	span := tc.newChildSpan(ctx)
 	defer func() {
 		span.FinishWithOptionsExt(tracer.WithError(err))

--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -9,8 +9,9 @@
 package ddtrace // import "github.com/signalfx/signalfx-go-tracing/ddtrace"
 
 import (
-	"github.com/opentracing/opentracing-go"
 	"time"
+
+	"github.com/opentracing/opentracing-go"
 )
 
 // Tracer specifies an implementation of the Datadog tracer which allows starting
@@ -94,4 +95,7 @@ type StartSpanConfig struct {
 	// Force-set the SpanID, rather than use a random number. If no Parent SpanContext is present,
 	// then this will also set the TraceID to the same value.
 	SpanID uint64
+
+	// RecordedValueMaxLength determines the maximum allowed length a tag/log can have.
+	RecordedValueMaxLength *int
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -49,6 +49,8 @@ type config struct {
 
 	// flag to disable injecting library tags
 	disableLibraryTags bool
+
+	recordedValueMaxLength *int
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -170,6 +172,16 @@ func WithoutLibraryTags() StartOption {
 	}
 }
 
+// WithTracerRecordedValueMaxLength specifies the maximum length a tag/log value
+// can have.
+// Values are completely truncated when set to 0.
+// Ignored when set to -1.
+func WithTracerRecordedValueMaxLength(l int) StartOption {
+	return func(c *config) {
+		c.recordedValueMaxLength = &l
+	}
+}
+
 // StartSpanOption is a configuration option for StartSpan. It is aliased in order
 // to help godoc group all the functions returning it together. It is considered
 // more correct to refer to it as the type as the origin, ddtrace.StartSpanOption.
@@ -203,6 +215,16 @@ func SpanType(name string) StartSpanOption {
 func WithSpanID(id uint64) StartSpanOption {
 	return func(cfg *ddtrace.StartSpanConfig) {
 		cfg.SpanID = id
+	}
+}
+
+// WithRecordedValueMaxLength specifies the maximum length a tag/log value
+// can have.
+// Values are completely truncated when set to 0.
+// Ignored when set to -1.
+func WithRecordedValueMaxLength(l int) StartSpanOption {
+	return func(cfg *ddtrace.StartSpanConfig) {
+		cfg.RecordedValueMaxLength = &l
 	}
 }
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -223,6 +223,7 @@ func (t *tracer) pushError(err error) {
 // StartSpan creates, starts, and returns a new Span with the given `operationName`.
 func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOption) ddtrace.Span {
 	var opts ddtrace.StartSpanConfig
+	opts.RecordedValueMaxLength = t.recordedValueMaxLength
 	for _, fn := range options {
 		fn(&opts)
 	}
@@ -244,15 +245,16 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	}
 	// span defaults
 	span := &span{
-		Name:     operationName,
-		Service:  t.config.serviceName,
-		Resource: operationName,
-		Meta:     map[string]string{},
-		Metrics:  map[string]float64{},
-		SpanID:   id,
-		TraceID:  id,
-		ParentID: 0,
-		Start:    startTime,
+		Name:                   operationName,
+		Service:                t.config.serviceName,
+		Resource:               operationName,
+		Meta:                   map[string]string{},
+		Metrics:                map[string]float64{},
+		SpanID:                 id,
+		TraceID:                id,
+		ParentID:               0,
+		Start:                  startTime,
+		recordedValueMaxLength: opts.RecordedValueMaxLength,
 	}
 	if context != nil {
 		// this is a child span


### PR DESCRIPTION
Added the following options

- tracing
    WithRecordedValueMaxLength

- ddtrace/tracer:
    WithTracerRecordedValueMaxLength
    WithRecordedValueMaxLength