### PR TITLE
Use GO111MODULE=auto for Go 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@ version: 2.1
 references:
   goexecutor: &goexecutor
     image: circleci/golang:latest
+    environment:
+      GO111MODULE: auto
 
   workdir: &workdir
     working_directory: /home/circleci/signalfx-go-tracing


### PR DESCRIPTION
## Why

https://blog.golang.org/go116-module-changes

## What

Set `GO111MODULE=auto` to make the CI build green.