### PR TITLE
Pin CircleCI to use Go 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 
 references:
   goexecutor: &goexecutor
-    image: circleci/golang:latest
+    image: circleci/golang:1.15
 
   workdir: &workdir
     working_directory: /home/circleci/signalfx-go-tracing


### PR DESCRIPTION
## Why

https://blog.golang.org/go116-module-changes

## What

Use Go 1.15 to make the CI build green.

##  Other comments

Initially, I tried #62 but it occurred that setting `GO111MODULE=auto` is not enough. 