### PR TITLE
Enable SIGNALFX_SERVER_TIMING_CONTEXT by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] 1.8.0
+
+### Changed
+
+- Enable `SIGNALFX_SERVER_TIMING_CONTEXT` by default. ([#96](https://github.com/signalfx/signalfx-go-tracing/pull/96))
 
 ## [1.7.0] - 2021-03-25
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ gendependabot:
 	done
 
 .PHONY: for-all
-for-all: # run a command in all modules, example: make for-all cmd="go mod tidy"
+for-all: # run a command in all modules, example: make for-all cmd="go test ./..."
 	@[ "$(cmd)" ] || ( echo ">> 'cmd' is not set"; exit 1 )
 	${call for-all-modules, $(cmd)}
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ If the default configuration values don't apply for your environment, override t
 | [WithEndpointURL](https://godoc.org/github.com/signalfx/signalfx-go-tracing/tracing/#WithEndpointURL) | `SIGNALFX_ENDPOINT_URL` | `http://localhost:9080/v1/trace` | The URL to send traces to. Send spans to a Smart Agent, OpenTelemetry Collector, or a SignalFx ingest endpoint.  |
 | [WithAccessToken](https://godoc.org/github.com/signalfx/signalfx-go-tracing/tracing/#WithAccessToken) | `SIGNALFX_ACCESS_TOKEN` | none | The access token for your SignalFx organization. |
 | [WithGlobalTag](https://godoc.org/github.com/signalfx/signalfx-go-tracing/tracing/#WithGlobalTag) | `SIGNALFX_SPAN_TAGS` | none | Comma-separated list of tags included in every reported span. For example, "key1:val1,key2:val2". Use only string values for tags.|
-| [WithRecordedValueMaxLength](https://godoc.org/github.com/signalfx/signalfx-go-tracing/tracing/#WithRecordedValueMaxLength) | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | 1200 | The maximum number of characters for any Zipkin-encoded tagged or logged value. Behaviour disabled when set to -1. |
-| - | `SIGNALFX_SERVER_TIMING_CONTEXT` | none | When set to `true`, adds `Server-Timing` header to HTTP responses for [net/http](contrib/net/http) and [github.com/gorilla/mux](contrib/gorilla/mux) instrumentations. |
+| [WithRecordedValueMaxLength](https://godoc.org/github.com/signalfx/signalfx-go-tracing/tracing/#WithRecordedValueMaxLength) | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `1200` | The maximum number of characters for any Zipkin-encoded tagged or logged value. Behaviour disabled when set to -1. |
+| - | `SIGNALFX_SERVER_TIMING_CONTEXT` | `true` | Adds `Server-Timing` header to HTTP responses for [net/http](contrib/net/http) and [github.com/gorilla/mux](contrib/gorilla/mux) instrumentations. |
 
 ## Instrument a Go application
 

--- a/contrib/internal/httputil/trace.go
+++ b/contrib/internal/httputil/trace.go
@@ -18,10 +18,10 @@ import (
 // TraceAndServe will apply tracing to the given http.Handler using the passed tracer under the given service and resource.
 func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, service, resource string, spanopts ...ddtrace.StartSpanOption) {
 	originalURL := url.URL{
-		Scheme: "http",
-		Host: r.Host,
-		RawPath: r.URL.RawPath,
-		Path: r.URL.Path,
+		Scheme:   "http",
+		Host:     r.Host,
+		RawPath:  r.URL.RawPath,
+		Path:     r.URL.Path,
 		RawQuery: r.URL.RawQuery,
 	}
 	if r.TLS != nil {
@@ -43,7 +43,7 @@ func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, servi
 
 	w = wrapResponseWriter(w, span)
 
-	if strings.EqualFold("true", os.Getenv("SIGNALFX_SERVER_TIMING_CONTEXT")) {
+	if v := os.Getenv("SIGNALFX_SERVER_TIMING_CONTEXT"); v == "" || v == "1" || strings.EqualFold(v, "true") {
 		if traceParent, ok := tracer.FormatAsTraceParent(span.Context()); ok {
 			w.Header().Add("Access-Control-Expose-Headers", "Server-Timing")
 			w.Header().Add("Server-Timing", traceParent)

--- a/contrib/internal/httputil/trace.go
+++ b/contrib/internal/httputil/trace.go
@@ -43,7 +43,7 @@ func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, servi
 
 	w = wrapResponseWriter(w, span)
 
-	if v := os.Getenv("SIGNALFX_SERVER_TIMING_CONTEXT"); v == "" || v == "1" || strings.EqualFold(v, "true") {
+	if v := os.Getenv("SIGNALFX_SERVER_TIMING_CONTEXT"); v == "" || v != "0" && !strings.EqualFold(v, "false") {
 		if traceParent, ok := tracer.FormatAsTraceParent(span.Context()); ok {
 			w.Header().Add("Access-Control-Expose-Headers", "Server-Timing")
 			w.Header().Add("Server-Timing", traceParent)


### PR DESCRIPTION
## Why

https://github.com/signalfx/gdi-specification/discussions/18#discussioncomment-554467

## What

- Enable `SIGNALFX_SERVER_TIMING_CONTEXT` by default.