### PR TITLE
Rename SIGNALFX_SERVER_TIMING_CONTEXT env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Enable `SIGNALFX_SERVER_TIMING_CONTEXT` by default. ([#96](https://github.com/signalfx/signalfx-go-tracing/pull/96))
+- Rename `SIGNALFX_SERVER_TIMING_CONTEXT` environmental variable to `SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED` and enable it by default. ([#96](https://github.com/signalfx/signalfx-go-tracing/pull/96)) ([#117](https://github.com/signalfx/signalfx-go-tracing/pull/117))
 
 ## [1.7.0] - 2021-03-25
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If the default configuration values don't apply for your environment, override t
 | [WithAccessToken](https://godoc.org/github.com/signalfx/signalfx-go-tracing/tracing/#WithAccessToken) | `SIGNALFX_ACCESS_TOKEN` | none | The access token for your SignalFx organization. |
 | [WithGlobalTag](https://godoc.org/github.com/signalfx/signalfx-go-tracing/tracing/#WithGlobalTag) | `SIGNALFX_SPAN_TAGS` | none | Comma-separated list of tags included in every reported span. For example, "key1:val1,key2:val2". Use only string values for tags.|
 | [WithRecordedValueMaxLength](https://godoc.org/github.com/signalfx/signalfx-go-tracing/tracing/#WithRecordedValueMaxLength) | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `1200` | The maximum number of characters for any Zipkin-encoded tagged or logged value. Behaviour disabled when set to -1. |
-| - | `SIGNALFX_SERVER_TIMING_CONTEXT` | `true` | Adds `Server-Timing` header to HTTP responses for [net/http](contrib/net/http) and [github.com/gorilla/mux](contrib/gorilla/mux) instrumentations. |
+| - | `SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED` | `true` | Adds `Server-Timing` header to HTTP responses for [net/http](contrib/net/http) and [github.com/gorilla/mux](contrib/gorilla/mux) instrumentations. |
 
 ## Instrument a Go application
 

--- a/contrib/internal/httputil/trace.go
+++ b/contrib/internal/httputil/trace.go
@@ -43,7 +43,7 @@ func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, servi
 
 	w = wrapResponseWriter(w, span)
 
-	if v := os.Getenv("SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED"); v == "" || v != "0" && !strings.EqualFold(v, "false") {
+	if v := os.Getenv("SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED"); !strings.EqualFold(v, "false") {
 		if traceParent, ok := tracer.FormatAsTraceParent(span.Context()); ok {
 			w.Header().Add("Access-Control-Expose-Headers", "Server-Timing")
 			w.Header().Add("Server-Timing", traceParent)

--- a/contrib/internal/httputil/trace.go
+++ b/contrib/internal/httputil/trace.go
@@ -43,7 +43,7 @@ func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, servi
 
 	w = wrapResponseWriter(w, span)
 
-	if v := os.Getenv("SIGNALFX_SERVER_TIMING_CONTEXT"); v == "" || v != "0" && !strings.EqualFold(v, "false") {
+	if v := os.Getenv("SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED"); v == "" || v != "0" && !strings.EqualFold(v, "false") {
 		if traceParent, ok := tracer.FormatAsTraceParent(span.Context()); ok {
 			w.Header().Add("Access-Control-Expose-Headers", "Server-Timing")
 			w.Header().Add("Server-Timing", traceParent)


### PR DESCRIPTION
## Why

Per https://github.com/signalfx/gdi-specification/pull/32

## What

- Rename `SIGNALFX_SERVER_TIMING_CONTEXT` environmental variable to `SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED`
- Parsing `SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED` fixed (ref: https://github.com/signalfx/splunk-otel-go/pull/30#discussion_r605997228)