### PR TITLE
Added messaging.destination tag to Sarama

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Sarama instrumentation now adds `message_bug.destination` attribute. ([#124](https://github.com/signalfx/signalfx-go-tracing/pull/124))
+
 ## [1.9.0] - 2021-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Sarama instrumentation now adds `message_bug.destination` attribute. ([#124](https://github.com/signalfx/signalfx-go-tracing/pull/124))
+- Sarama instrumentation now adds `message_bus.destination` attribute. ([#124](https://github.com/signalfx/signalfx-go-tracing/pull/124))
 
 ## [1.9.0] - 2021-04-14
 

--- a/contrib/Shopify/sarama/sarama.go
+++ b/contrib/Shopify/sarama/sarama.go
@@ -45,7 +45,7 @@ func WrapPartitionConsumer(pc sarama.PartitionConsumer, opts ...Option) sarama.P
 				tracer.SpanType(ext.SpanTypeMessageConsumer),
 				tracer.Tag("partition", msg.Partition),
 				tracer.Tag("offset", msg.Offset),
-				tracer.Tag("peer.service", cfg.peerServiceName),
+				tracer.Tag(ext.PeerService, cfg.peerServiceName),
 			}
 			if cfg.analyticsRate > 0 {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
@@ -248,7 +248,8 @@ func startProducerSpan(cfg *config, version sarama.KafkaVersion, msg *sarama.Pro
 		tracer.ServiceName(cfg.serviceName),
 		tracer.ResourceName("Produce Topic " + msg.Topic),
 		tracer.SpanType(ext.SpanTypeMessageProducer),
-		tracer.Tag("peer.service", cfg.peerServiceName),
+		tracer.Tag(ext.PeerService, cfg.peerServiceName),
+		tracer.Tag(ext.MessageBusDestination, msg.Topic),
 	}
 	if cfg.analyticsRate > 0 {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))

--- a/contrib/Shopify/sarama/sarama_test.go
+++ b/contrib/Shopify/sarama/sarama_test.go
@@ -219,6 +219,8 @@ func TestAsyncProducer(t *testing.T) {
 			assert.Equal(t, "producer", s.Tag(ext.SpanType))
 			assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 			assert.Equal(t, "kafka.produce", s.OperationName())
+			assert.Equal(t, "my_topic", s.Tag(ext.MessageBusDestination))
+			assert.Equal(t, "kafka", s.Tag(ext.PeerService))
 			assert.Equal(t, int32(0), s.Tag("partition"))
 			assert.Equal(t, int64(0), s.Tag("offset"))
 		}
@@ -257,6 +259,8 @@ func TestAsyncProducer(t *testing.T) {
 			assert.Equal(t, "producer", s.Tag(ext.SpanType))
 			assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 			assert.Equal(t, "kafka.produce", s.OperationName())
+			assert.Equal(t, "my_topic", s.Tag(ext.MessageBusDestination))
+			assert.Equal(t, "kafka", s.Tag(ext.PeerService))
 			assert.Equal(t, int32(0), s.Tag("partition"))
 			assert.Equal(t, int64(0), s.Tag("offset"))
 		}

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -100,6 +100,10 @@ const (
 	// Stack is a stack trace
 	Stack = "stack"
 
+	// MessageBusDestination is an address at which messages can be exchanged in a messaging
+	// system such as kafka.
+	MessageBusDestination = "message_bus.destination"
+
 	// SFXTracingLibrary specifies the SignalFx tracing library that generated the span.
 	SFXTracingLibrary = "signalfx.tracing.library"
 


### PR DESCRIPTION
`message_bus.destination` was missing from Sarama spans. This commit adds it.