### PR TITLE
Fix deadlock and race condition in sarama instrumentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix deadlock and race condition in sarama instrumentation. ([#128](https://github.com/signalfx/signalfx-go-tracing/pull/128))
+
 ## [1.9.1] - 2021-04-15
 
 ### Added

--- a/contrib/Shopify/sarama/sarama.go
+++ b/contrib/Shopify/sarama/sarama.go
@@ -211,7 +211,7 @@ func WrapAsyncProducer(saramaConfig *sarama.Config, p sarama.AsyncProducer, opts
 					// if returning successes isn't enabled, we just finish the
 					// span right away because there's no way to know when it will
 					// be done
-					finishProducerSpan(span, msg.Partition, msg.Offset, nil)
+					span.FinishWithOptionsExt()
 				}
 			case msg, ok := <-p.Successes():
 				if !ok {

--- a/contrib/Shopify/sarama/sarama.go
+++ b/contrib/Shopify/sarama/sarama.go
@@ -172,6 +172,9 @@ func (p *asyncProducer) Errors() <-chan *sarama.ProducerError {
 // WrapAsyncProducer wraps a sarama.AsyncProducer so that all produced messages
 // are traced. It requires the underlying sarama Config so we can know whether
 // or not sucesses will be returned.
+//
+// Remarks: Do not access Offset, Partition, Timestampsarama.ProducerMessage fields
+// before the message is processed by the producer as this can result in data races.
 func WrapAsyncProducer(saramaConfig *sarama.Config, p sarama.AsyncProducer, opts ...Option) sarama.AsyncProducer {
 	cfg := new(config)
 	defaults(cfg)

--- a/contrib/Shopify/sarama/sarama.go
+++ b/contrib/Shopify/sarama/sarama.go
@@ -208,9 +208,11 @@ func WrapAsyncProducer(saramaConfig *sarama.Config, p sarama.AsyncProducer, opts
 				if headersSupported && saramaConfig.Producer.Return.Successes {
 					spans[tracer.SpanID(span.Context())] = span
 				} else {
-					// if returning successes isn't enabled, we just finish the
-					// span right away because there's no way to know when it will
-					// be done
+					// If returning successes isn't enabled, we just finish the span right away,
+					// because there's no way to know when it will be done.
+					// Note: Partition and Offset fields should not be accessed
+					// until the message is successfully published
+					// as this can result in data races.
 					span.FinishWithOptionsExt()
 				}
 			case msg, ok := <-p.Successes():

--- a/contrib/Shopify/sarama/sarama.go
+++ b/contrib/Shopify/sarama/sarama.go
@@ -197,6 +197,7 @@ func WrapAsyncProducer(saramaConfig *sarama.Config, p sarama.AsyncProducer, opts
 	}
 	go func() {
 		spans := make(map[uint64]ddtrace.Span)
+		defer close(wrapped.input)
 		defer close(wrapped.successes)
 		defer close(wrapped.errors)
 		for {

--- a/contrib/Shopify/sarama/sarama_test.go
+++ b/contrib/Shopify/sarama/sarama_test.go
@@ -221,8 +221,8 @@ func TestAsyncProducer(t *testing.T) {
 			assert.Equal(t, "kafka.produce", s.OperationName())
 			assert.Equal(t, "my_topic", s.Tag(ext.MessageBusDestination))
 			assert.Equal(t, "kafka", s.Tag(ext.PeerService))
-			assert.Equal(t, int32(0), s.Tag("partition"))
-			assert.Equal(t, int64(0), s.Tag("offset"))
+			assert.Nil(t, s.Tag("partition"))
+			assert.Nil(t, s.Tag("offset"))
 		}
 	})
 


### PR DESCRIPTION
## Race condition when reading message Partition and Offset

Sample race condition:

```
==================
WARNING: DATA RACE
Write at 0x00c0250fca60 by goroutine 217:
  github.com/Shopify/sarama.(*topicProducer).partitionMessage()
      /.../go/pkg/mod/github.com/!shopify/sarama@v1.27.0/async_producer.go:467 +0x207
  github.com/Shopify/sarama.(*topicProducer).dispatch()
      /.../go/pkg/mod/github.com/!shopify/sarama@v1.27.0/async_producer.go:410 +0x2e5
  github.com/Shopify/sarama.(*topicProducer).dispatch-fm()
      /.../go/pkg/mod/github.com/!shopify/sarama@v1.27.0/async_producer.go:407 +0x41
  github.com/Shopify/sarama.withRecover()
      /.../go/pkg/mod/github.com/!shopify/sarama@v1.27.0/utils.go:43 +0x5a
Previous read at 0x00c0250fca60 by goroutine 44:
  github.com/signalfx/signalfx-go-tracing/contrib/Shopify/sarama.WrapAsyncProducer.func1()
      /.../go/pkg/mod/github.com/signalfx/signalfx-go-tracing/contrib/!shopify/sarama@v1.9.0/sarama.go:213 +0x900
Goroutine 217 (running) created at:
  github.com/Shopify/sarama.(*asyncProducer).newTopicProducer()
      /.../go/pkg/mod/github.com/!shopify/sarama@v1.27.0/async_producer.go:403 +0x390
  github.com/Shopify/sarama.(*asyncProducer).dispatcher()
      /.../go/pkg/mod/github.com/!shopify/sarama@v1.27.0/async_producer.go:369 +0x739
  github.com/Shopify/sarama.(*asyncProducer).dispatcher-fm()
      /.../go/pkg/mod/github.com/!shopify/sarama@v1.27.0/async_producer.go:322 +0x41
  github.com/Shopify/sarama.withRecover()
      /.../go/pkg/mod/github.com/!shopify/sarama@v1.27.0/utils.go:43 +0x5a
Goroutine 44 (running) created at:
  github.com/signalfx/signalfx-go-tracing/contrib/Shopify/sarama.WrapAsyncProducer()
      /.../go/pkg/mod/github.com/signalfx/signalfx-go-tracing/contrib/!shopify/sarama@v1.9.0/sarama.go:198 +0x3b0
  github.com/Vungle/jaeger/internal/kafka.newProducer()
      /.../go/src/github.com/Vungle/jaeger/internal/kafka/producer.go:98 +0x198
  github.com/Vungle/jaeger/internal/kafka.Initialize()
      /.../go/src/github.com/Vungle/jaeger/internal/kafka/kafka.go:16 +0xd6
  github.com/Vungle/jaeger/internal/services.Services.Initialize()
      /.../go/src/github.com/Vungle/jaeger/internal/services/services.go:24 +0x15c
  main.init.0()
      /.../go/src/github.com/Vungle/jaeger/cmd/jaeger/jaeger.go:96 +0x24c
```

The race was caused b/c the thread tried to access data (Partition and Offset) before it was processed. Take notice: https://github.com/Shopify/sarama/blob/41df78df10a9ef3c807cbe1f2814001e330fbdf1/async_producer.go#L200-L208 

I guess the "code" assumed that it was using Kafka 0.8.2.0 while probably the Kafka was newer. The "code" was hitting this use case: https://github.com/signalfx/signalfx-go-tracing/blob/27c9fc0b521e0e6513306759567a524a9728ba6d/contrib/Shopify/sarama/sarama.go#L187-L190 

⚠️ **Same bug in OTel:** https://github.com/open-telemetry/opentelemetry-go-contrib/blob/e1a7c4781baf5716364bc5661052c5746e87e344/instrumentation/github.com/Shopify/sarama/otelsarama/producer.go#L197

✔️ **No bug in Datadog:** https://github.com/DataDog/dd-trace-go/blob/2fbd304cbd6f023287ed44526ca3a4f7b292b6ad/contrib/Shopify/sarama/sarama.go#L220

## Deadlock when sending a message to the Input channel

The client can still write to the `input` channel after the goroutine created by `WrapAsyncProducer` was already shut down. Therefore the channel should be closed.

⚠️ **Same bug in OTel:** https://github.com/open-telemetry/opentelemetry-go-contrib/blob/e1a7c4781baf5716364bc5661052c5746e87e344/instrumentation/github.com/Shopify/sarama/otelsarama/producer.go#L158-L159

⚠️ **Same bug in Datadog:** https://github.com/DataDog/dd-trace-go/blob/2fbd304cbd6f023287ed44526ca3a4f7b292b6ad/contrib/Shopify/sarama/sarama.go#L206-L207
