### PR TITLE
Fix B3 propagation headers injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Add leading zeros to the B3 propagation `x-b3-traceid` and `x-b3-spanid` headers so that they are always 16 characters long. ([#149](https://github.com/signalfx/signalfx-go-tracing/pull/149))
+
 ## [1.9.2] - 2021-04-19
 
 ### Fixed

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -301,8 +301,8 @@ func (*propagatorB3) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWr
 	if !ok || ctx.traceID == 0 || ctx.spanID == 0 {
 		return ErrInvalidSpanContext
 	}
-	writer.Set(b3TraceIDHeader, strconv.FormatUint(ctx.traceID, 16))
-	writer.Set(b3SpanIDHeader, strconv.FormatUint(ctx.spanID, 16))
+	writer.Set(b3TraceIDHeader, toHex(ctx.traceID))
+	writer.Set(b3SpanIDHeader, toHex(ctx.spanID))
 	if ctx.hasSamplingPriority() {
 		if ctx.samplingPriority() >= ext.PriorityAutoKeep {
 			writer.Set(b3SampledHeader, "1")

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -3,11 +3,13 @@ package tracer
 
 import (
 	"errors"
-	"github.com/signalfx/signalfx-go-tracing/ddtrace"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/signalfx/signalfx-go-tracing/ddtrace"
 
 	"github.com/signalfx/signalfx-go-tracing/ddtrace/ext"
 	"github.com/stretchr/testify/assert"
@@ -223,8 +225,8 @@ func TestB3(t *testing.T) {
 		assert := assert.New(t)
 		assert.Nil(err)
 
-		assert.Equal(headers[b3TraceIDHeader], strconv.FormatUint(root.TraceID, 16))
-		assert.Equal(headers[b3SpanIDHeader], strconv.FormatUint(root.SpanID, 16))
+		assert.Equal(headers[b3TraceIDHeader], fmt.Sprintf("%016x", root.TraceID))
+		assert.Equal(headers[b3SpanIDHeader], fmt.Sprintf("%016x", root.SpanID))
 		assert.Equal(headers[b3SampledHeader], "0")
 	})
 

--- a/ddtrace/tracer/util.go
+++ b/ddtrace/tracer/util.go
@@ -1,6 +1,8 @@
 package tracer
 
 import (
+	"encoding/binary"
+	"encoding/hex"
 	"strconv"
 	"strings"
 )
@@ -47,4 +49,11 @@ func parseUint64(str string) (uint64, error) {
 		return uint64(id), nil
 	}
 	return strconv.ParseUint(str, 10, 64)
+}
+
+// toHex converts the uint64 to a 16 lower-hex characters representation.
+func toHex(value uint64) string {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, value)
+	return hex.EncodeToString(b)
 }

--- a/ddtrace/tracer/util_test.go
+++ b/ddtrace/tracer/util_test.go
@@ -3,6 +3,7 @@ package tracer
 import (
 	"fmt"
 	"math"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,4 +58,26 @@ func TestParseUint64(t *testing.T) {
 		_, err := parseUint64("abcd")
 		assert.Error(t, err)
 	})
+}
+
+func TestToHex(t *testing.T) {
+	testCases := []struct {
+		in   uint64
+		want string
+	}{
+		{0, "0000000000000000"},
+		{1, "0000000000000001"},
+		{255, "00000000000000ff"},
+		{123456, "000000000001e240"},
+	}
+	for _, tc := range testCases {
+		got := toHex(tc.in)
+		assert.Equal(t, tc.want, got)
+	}
+}
+
+func BenchmarkToHex(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		toHex(rand.Uint64())
+	}
 }


### PR DESCRIPTION
## What

Add leading zeros to the B3 propagation `x-b3-traceid` and `x-b3-spanid` headers so that they are always 16 characters long as required by the [specification](https://github.com/openzipkin/b3-propagation#traceid-1).

## Benchmarks

```go
func BenchmarkToHex(b *testing.B) {
	for i := 0; i < b.N; i++ {
		toHex(rand.Uint64())
	}
}
```

### Current implementation

``` go
func toHex(value uint64) string {
	b := make([]byte, 8)
	binary.BigEndian.PutUint64(b, value)
	return hex.EncodeToString(b)
}
```

```sh
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^(BenchmarkToHex)$ github.com/signalfx/signalfx-go-tracing/ddtrace/tracer

goos: linux
goarch: amd64
pkg: github.com/signalfx/signalfx-go-tracing/ddtrace/tracer
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
BenchmarkToHex-16    	21657834	        55.59 ns/op	      32 B/op	       2 allocs/op
PASS
ok  	github.com/signalfx/signalfx-go-tracing/ddtrace/tracer	1.268s
```

### Alternative implementation

```go
func toHex(value uint64) string {
	return fmt.Sprintf("%016x", value)
}
```

```sh
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^(BenchmarkToHex2)$ github.com/signalfx/signalfx-go-tracing/ddtrace/tracer

goos: linux
goarch: amd64
pkg: github.com/signalfx/signalfx-go-tracing/ddtrace/tracer
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
BenchmarkToHex2-16    	 8361780	       142.4 ns/op	      24 B/op	       2 allocs/op
PASS
ok  	github.com/signalfx/signalfx-go-tracing/ddtrace/tracer	1.343s
```