### PR TITLE
Use Bash as default shell in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .DEFAULT_GOAL := build
+SHELL := /bin/bash
 
 GO = go
 


### PR DESCRIPTION
## Why

The `*-tag` Make targets are using Bash syntax.

## What

Set Bash as the shell in `Makefile`.