### PR TITLE
Add redigo.WithSpanOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Addded
+
+- Add `redigo.WithSpanOptions` to the `github.com/gomodule/redigo` instrumentation.
+
 ## [1.9.3] - 2021-06-15
 
 ### Fixed
@@ -213,7 +217,7 @@ created by testing.(*T).Run
 - Add SpanKind for gRPC Server and Client. ([#25](https://github.com/signalfx/signalfx-go-tracing/pull/25))
 
 [Unreleased]: https://github.com/signalfx/signalfx-go-tracing/compare/v1.9.3...HEAD
-[1.9.2]: https://github.com/signalfx/signalfx-go-tracing/releases/tag/v1.9.3
+[1.9.3]: https://github.com/signalfx/signalfx-go-tracing/releases/tag/v1.9.3
 [1.9.2]: https://github.com/signalfx/signalfx-go-tracing/releases/tag/v1.9.2
 [1.9.1]: https://github.com/signalfx/signalfx-go-tracing/releases/tag/v1.9.1
 [1.9.0]: https://github.com/signalfx/signalfx-go-tracing/releases/tag/v1.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-### Addded
+### Added
 
-- Add `redigo.WithSpanOptions` to the `github.com/gomodule/redigo` instrumentation.
+- Add `redigo.WithSpanOptions` to the `github.com/gomodule/redigo` instrumentation. ([#157](https://github.com/signalfx/signalfx-go-tracing/pull/157))
 
 ## [1.9.3] - 2021-06-15
 

--- a/contrib/gomodule/redigo/option.go
+++ b/contrib/gomodule/redigo/option.go
@@ -1,8 +1,11 @@
 package redigo // import "github.com/signalfx/signalfx-go-tracing/contrib/gomodule/redigo"
 
+import "github.com/signalfx/signalfx-go-tracing/ddtrace"
+
 type dialConfig struct {
 	serviceName   string
 	analyticsRate float64
+	spanOpts      []ddtrace.StartSpanOption
 }
 
 // DialOption represents an option that can be passed to Dial.
@@ -33,5 +36,13 @@ func WithAnalytics(on bool) DialOption {
 func WithAnalyticsRate(rate float64) DialOption {
 	return func(cfg *dialConfig) {
 		cfg.analyticsRate = rate
+	}
+}
+
+// WithSpanOptions defines a set of additional ddtrace.StartSpanOption to be added
+// to spans started by the integration.
+func WithSpanOptions(opts ...ddtrace.StartSpanOption) DialOption {
+	return func(cfg *dialConfig) {
+		cfg.spanOpts = append(cfg.spanOpts, opts...)
 	}
 }

--- a/contrib/gomodule/redigo/redigo.go
+++ b/contrib/gomodule/redigo/redigo.go
@@ -90,12 +90,12 @@ func DialURL(rawurl string, options ...interface{}) (redis.Conn, error) {
 // newChildSpan creates a span inheriting from the given context. It adds to the span useful metadata about the traced Redis connection
 func (tc Conn) newChildSpan(ctx context.Context) ddtrace.Span {
 	p := tc.params
-	opts := []ddtrace.StartSpanOption{
+	opts := append([]ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeRedis),
 		tracer.ServiceName(p.config.serviceName),
 		tracer.Tag(ext.DBType, "redis"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
-	}
+	}, p.config.spanOpts...)
 	if rate := p.config.analyticsRate; rate > 0 {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
 	}

--- a/contrib/gomodule/redigo/redigo_test.go
+++ b/contrib/gomodule/redigo/redigo_test.go
@@ -28,7 +28,7 @@ func TestClient(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	c, err := Dial("tcp", "127.0.0.1:6379", WithServiceName("my-service"))
+	c, err := Dial("tcp", "127.0.0.1:6379", WithServiceName("my-service"), WithSpanOptions(tracer.Tag("foo", "bar")))
 	assert.Nil(err)
 	c.Do("SET", 1, "truck")
 
@@ -46,6 +46,7 @@ func TestClient(t *testing.T) {
 	assert.Equal("redis", span.Tag(ext.DBType))
 	assert.Equal("SET 1 truck", span.Tag("redis.raw_command"))
 	assert.Equal("2", span.Tag("redis.args_length"))
+	assert.Equal("bar", span.Tag("foo"))
 }
 
 func TestCommandError(t *testing.T) {


### PR DESCRIPTION
## Why

Solves https://github.com/signalfx/signalfx-go-tracing/issues/156

## What

Add missing `redigo.WithSpanOptions` to the https://github.com/gomodule/redigo instrumentation.