### PR TITLE
Fix confluent-kafka-go module path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fix Confluent Kafka Client instrumentation module path. ([#163](https://github.com/signalfx/signalfx-go-tracing/pull/163))
 - Bump [github.com/tinylib/msgp](https://github.com/tinylib/msgp) from 1.1.5 to [1.1.6](https://github.com/tinylib/msgp/releases/tag/v1.1.6). ([#153](https://github.com/signalfx/signalfx-go-tracing/pull/153))
 
 ## [1.10.0] - 2021-06-30

--- a/contrib/confluentinc/confluent-kafka-go/kafka/go.mod
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/go.mod
@@ -1,4 +1,4 @@
-module github.com/signalfx/signalfx-go-tracing/confluentinc/confluent-kafka-go/kafka
+module github.com/signalfx/signalfx-go-tracing/contrib/confluentinc/confluent-kafka-go/kafka
 
 go 1.12
 


### PR DESCRIPTION
## Why

I noticed the module path is wrong:

```
godoc for contrib/confluentinc/confluent-kafka-go/kafka
go get: github.com/signalfx/signalfx-go-tracing/contrib/confluentinc/confluent-kafka-go/kafka@none updating to
        github.com/signalfx/signalfx-go-tracing/contrib/confluentinc/confluent-kafka-go/kafka@v1.10.0: parsing go.mod:
        module declares its path as: github.com/signalfx/signalfx-go-tracing/confluentinc/confluent-kafka-go/kafka
                but was required as: github.com/signalfx/signalfx-go-tracing/contrib/confluentinc/confluent-kafka-go/kafka
make: *** [Makefile:62: publish-godoc] Error 1
```

## What

Fix the module path.