### PR TITLE
Release v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.11.0] - 2021-09-08
+
 ### Fixed
 
 - Fix Confluent Kafka Client instrumentation module path. ([#163](https://github.com/signalfx/signalfx-go-tracing/pull/163))
@@ -224,7 +226,8 @@ created by testing.(*T).Run
 
 - Add SpanKind for gRPC Server and Client. ([#25](https://github.com/signalfx/signalfx-go-tracing/pull/25))
 
-[Unreleased]: https://github.com/signalfx/signalfx-go-tracing/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/signalfx/signalfx-go-tracing/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/signalfx/signalfx-go-tracing/releases/tag/v1.11.0
 [1.10.0]: https://github.com/signalfx/signalfx-go-tracing/releases/tag/v1.10.0
 [1.9.3]: https://github.com/signalfx/signalfx-go-tracing/releases/tag/v1.9.3
 [1.9.2]: https://github.com/signalfx/signalfx-go-tracing/releases/tag/v1.9.2

--- a/contrib/Shopify/sarama/go.mod
+++ b/contrib/Shopify/sarama/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/Shopify/sarama v1.26.1
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/aws/aws-sdk-go/aws/go.mod
+++ b/contrib/aws/aws-sdk-go/aws/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/aws/aws-sdk-go v1.30.9
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/bradfitz/gomemcache/memcache/go.mod
+++ b/contrib/bradfitz/gomemcache/memcache/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/confluentinc/confluent-kafka-go/kafka/go.mod
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/confluentinc/confluent-kafka-go v1.4.0
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/database/sql/go.mod
+++ b/contrib/database/sql/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/lib/pq v1.2.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 	gotest.tools v2.2.0+incompatible
 )

--- a/contrib/emicklei/go-restful/go.mod
+++ b/contrib/emicklei/go-restful/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/emicklei/go-restful v2.12.0+incompatible
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/garyburd/redigo/go.mod
+++ b/contrib/garyburd/redigo/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/garyburd/redigo v1.6.0
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/gin-gonic/gin/go.mod
+++ b/contrib/gin-gonic/gin/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/gin-gonic/gin v1.6.2
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/globalsign/mgo/go.mod
+++ b/contrib/globalsign/mgo/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/go-chi/chi/go.mod
+++ b/contrib/go-chi/chi/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/go-chi/chi v4.1.1+incompatible
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/go-redis/redis/go.mod
+++ b/contrib/go-redis/redis/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/go-redis/redis v6.15.7+incompatible
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/gocql/gocql/go.mod
+++ b/contrib/gocql/gocql/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/gocql/gocql v0.0.0-20200410100145-b454769479c6
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/gomodule/redigo/go.mod
+++ b/contrib/gomodule/redigo/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/gomodule/redigo v2.0.0+incompatible
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/google.golang.org/api/go.mod
+++ b/contrib/google.golang.org/api/go.mod
@@ -3,8 +3,8 @@ module github.com/signalfx/signalfx-go-tracing/contrib/google.golang.org/api
 go 1.12
 
 require (
-	github.com/signalfx/signalfx-go-tracing v1.10.0
-	github.com/signalfx/signalfx-go-tracing/contrib/net/http v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
+	github.com/signalfx/signalfx-go-tracing/contrib/net/http v1.11.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	google.golang.org/api v0.21.0

--- a/contrib/google.golang.org/grpc.v12/go.mod
+++ b/contrib/google.golang.org/grpc.v12/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/golang/protobuf v1.4.0
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	google.golang.org/grpc v1.28.1

--- a/contrib/google.golang.org/grpc/go.mod
+++ b/contrib/google.golang.org/grpc/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/golang/protobuf v1.4.0
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	google.golang.org/grpc v1.28.1

--- a/contrib/gorilla/mux/go.mod
+++ b/contrib/gorilla/mux/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/gorilla/mux v1.7.4
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/graph-gophers/graphql-go/go.mod
+++ b/contrib/graph-gophers/graphql-go/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/graph-gophers/graphql-go v0.0.0-20200309224638-dae41bde9ef9
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/jinzhu/gorm/go.mod
+++ b/contrib/jinzhu/gorm/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/jinzhu/gorm v1.9.12
 	github.com/lib/pq v1.2.0
-	github.com/signalfx/signalfx-go-tracing v1.10.0
-	github.com/signalfx/signalfx-go-tracing/contrib/database/sql v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
+	github.com/signalfx/signalfx-go-tracing/contrib/database/sql v1.11.0
 )
 
 replace (

--- a/contrib/jmoiron/sqlx/go.mod
+++ b/contrib/jmoiron/sqlx/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.2.0
-	github.com/signalfx/signalfx-go-tracing v1.10.0
-	github.com/signalfx/signalfx-go-tracing/contrib/database/sql v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
+	github.com/signalfx/signalfx-go-tracing/contrib/database/sql v1.11.0
 )
 
 replace (

--- a/contrib/julienschmidt/httprouter/go.mod
+++ b/contrib/julienschmidt/httprouter/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/k8s.io/client-go/kubernetes/go.mod
+++ b/contrib/k8s.io/client-go/kubernetes/go.mod
@@ -3,8 +3,8 @@ module github.com/signalfx/signalfx-go-tracing/contrib/k8s.io/client-go/kubernet
 go 1.12
 
 require (
-	github.com/signalfx/signalfx-go-tracing v1.10.0
-	github.com/signalfx/signalfx-go-tracing/contrib/net/http v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
+	github.com/signalfx/signalfx-go-tracing/contrib/net/http v1.11.0
 	github.com/stretchr/testify v1.7.0
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/client-go v0.0.0-20190819141724-e14f31a72a77

--- a/contrib/labstack/echo.v4/go.mod
+++ b/contrib/labstack/echo.v4/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/labstack/echo/v4 v4.2.1
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/labstack/echo/go.mod
+++ b/contrib/labstack/echo/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/miekg/dns/go.mod
+++ b/contrib/miekg/dns/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/miekg/dns v1.1.29
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/mongodb/mongo-go-driver/mongo/go.mod
+++ b/contrib/mongodb/mongo-go-driver/mongo/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/signalfx-go-tracing/contrib/mongodb/mongo-go-driver/m
 go 1.12
 
 require (
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 	go.mongodb.org/mongo-driver v1.3.2
 )

--- a/contrib/net/http/go.mod
+++ b/contrib/net/http/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/signalfx-go-tracing/contrib/net/http
 go 1.12
 
 require (
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/contrib/olivere/elastic/go.mod
+++ b/contrib/olivere/elastic/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/signalfx-go-tracing/contrib/olivere/elastic
 go 1.12
 
 require (
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/olivere/elastic.v3 v3.0.75
 	gopkg.in/olivere/elastic.v5 v5.0.85

--- a/contrib/syndtr/goleveldb/leveldb/go.mod
+++ b/contrib/syndtr/goleveldb/leveldb/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/signalfx-go-tracing/contrib/syndtr/goleveldb/leveldb
 go 1.12
 
 require (
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/goleveldb v1.0.0
 )

--- a/contrib/tidwall/buntdb/go.mod
+++ b/contrib/tidwall/buntdb/go.mod
@@ -3,7 +3,7 @@ module github.com/signalfx/signalfx-go-tracing/contrib/tidwall/buntdb
 go 1.12
 
 require (
-	github.com/signalfx/signalfx-go-tracing v1.10.0
+	github.com/signalfx/signalfx-go-tracing v1.11.0
 	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/buntdb v1.2.0
 )

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package sfxtracing
 
 const LibraryName = "go-tracing"
-const Version = "1.10.0"
+const Version = "1.11.0"


### PR DESCRIPTION
### Fixed

- Fix Confluent Kafka Client instrumentation module path. ([#163](https://github.com/signalfx/signalfx-go-tracing/pull/163))
- Bump [github.com/tinylib/msgp](https://github.com/tinylib/msgp) from 1.1.5 to [1.1.6](https://github.com/tinylib/msgp/releases/tag/v1.1.6). ([#153](https://github.com/signalfx/signalfx-go-tracing/pull/153))
- Fix panic when context contains noop opentracing span. ([#173](https://github.com/signalfx/signalfx-go-tracing/pull/173))