### PR TITLE
Add NoDebugStack option to http.RoundTripper instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Add `http.RTWithNoDebugStack` to the `net/http.RoundTripper` instrumentation. ([#177](https://github.com/signalfx/signalfx-go-tracing/pull/177))
+
 ## [1.11.0] - 2021-09-08
 
 ### Fixed

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -67,6 +67,7 @@ type roundTripperConfig struct {
 	before        RoundTripperBeforeFunc
 	after         RoundTripperAfterFunc
 	analyticsRate float64
+	noDebugStack  bool
 }
 
 func newRoundTripperConfig() *roundTripperConfig {
@@ -108,5 +109,14 @@ func RTWithAnalytics(on bool) RoundTripperOption {
 func RTWithAnalyticsRate(rate float64) RoundTripperOption {
 	return func(cfg *roundTripperConfig) {
 		cfg.analyticsRate = rate
+	}
+}
+
+// RTWithNoDebugStack prevents stack traces from being attached to spans finishing
+// with an error. This is useful in situations where errors are frequent and
+// performance is critical.
+func RTWithNoDebugStack() RoundTripperOption {
+	return func(cfg *roundTripperConfig) {
+		cfg.noDebugStack = true
 	}
 }


### PR DESCRIPTION
## Why

Solves https://github.com/signalfx/signalfx-go-tracing/issues/176

## What

Add `http.RTWithNoDebugStack` to the `net/http.RoundTripper` instrumentation.